### PR TITLE
mark cull-less-leaves as broken with moreculling

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,6 +29,9 @@
     "minecraft": "1.18.x",
     "java": ">=17"
   },
+  "breaks": {
+    "cull-less-leaves": "*"
+  },
   "custom": {
     "mc-publish": {
       "curseforge": 630104,


### PR DESCRIPTION
I think this would benefit the both of us for not receiving duplicate issues about this error message. Instead provide a useful error message to the end user.