### PR TITLE
Only check unmipmapped sprite images for opacity

### DIFF
--- a/src/api/java/ca/fxco/moreculling/api/sprite/SpriteOpacity.java
+++ b/src/api/java/ca/fxco/moreculling/api/sprite/SpriteOpacity.java
@@ -16,9 +16,10 @@ public interface SpriteOpacity {
     /**
      * Change the images in a sprite that should be used for culling.
      * Only use this if you know what you are doing!
+     *
      * @since 0.7.0
      */
-    NativeImage[] getImages();
+    NativeImage getUnmipmappedImage();
 
     /**
      * States if the sprite has any fully transparent pixels.
@@ -46,7 +47,7 @@ public interface SpriteOpacity {
      * MoreCulling will skip optimizations on blocks that use these sprites and match the conditions
      * @since 0.8.0
      */
-    default boolean hasTranslucency(@Nullable List<NativeImage[]> quadNatives) {
+    default boolean hasTranslucency(@Nullable List<NativeImage> quadNatives) {
         return true;
     }
 }

--- a/src/main/java/ca/fxco/moreculling/mixin/Sprite_opacityMixin.java
+++ b/src/main/java/ca/fxco/moreculling/mixin/Sprite_opacityMixin.java
@@ -19,16 +19,13 @@ public class Sprite_opacityMixin implements SpriteOpacity {
     protected NativeImage[] images;
 
     @Override
-    public NativeImage[] getImages() {
-        return this.images;
+    public NativeImage getUnmipmappedImage() {
+        return this.images[0];
     }
 
     @Override
     public boolean hasTransparency() {
-        for (NativeImage nativeImage : getImages())
-            if (SpriteUtils.doesHaveTransparency(nativeImage))
-                return true;
-        return false;
+        return SpriteUtils.doesHaveTransparency(getUnmipmappedImage());
     }
 
     @Override
@@ -37,10 +34,7 @@ public class Sprite_opacityMixin implements SpriteOpacity {
     }
 
     @Override
-    public boolean hasTranslucency(@Nullable List<NativeImage[]> quadNatives) {
-        for (NativeImage nativeImage : getImages())
-            if (SpriteUtils.doesHaveTranslucency(nativeImage, quadNatives))
-                return true;
-        return false;
+    public boolean hasTranslucency(@Nullable List<NativeImage> quadNatives) {
+        return SpriteUtils.doesHaveTranslucency(getUnmipmappedImage(), quadNatives);
     }
 }

--- a/src/main/java/ca/fxco/moreculling/mixin/models/BasicBakedModel_cacheMixin.java
+++ b/src/main/java/ca/fxco/moreculling/mixin/models/BasicBakedModel_cacheMixin.java
@@ -52,8 +52,8 @@ public abstract class BasicBakedModel_cacheMixin implements BakedOpacity {
         hasTranslucency = ((SpriteOpacity)sprite).hasTranslucency();
         for (BakedQuad quad : quads) {
             if (((SpriteOpacity)quad.getSprite()).hasTranslucency()) {
-                List<NativeImage[]> quadNatives = quads.stream().map((q) ->
-                        ((SpriteOpacity)q.getSprite()).getImages()
+                List<NativeImage> quadNatives = quads.stream().map((q) ->
+                        ((SpriteOpacity)q.getSprite()).getUnmipmappedImage()
                 ).collect(Collectors.toList());
                 for (List<BakedQuad> bakedList : faceQuads.values()) {
                     for (BakedQuad baked : bakedList) {

--- a/src/main/java/ca/fxco/moreculling/utils/SpriteUtils.java
+++ b/src/main/java/ca/fxco/moreculling/utils/SpriteUtils.java
@@ -31,18 +31,16 @@ public class SpriteUtils {
         return false;
     }
 
-    public static boolean doesHaveTranslucency(NativeImage image, @Nullable List<NativeImage[]> orMatch) {
+    public static boolean doesHaveTranslucency(NativeImage image, @Nullable List<NativeImage> orMatch) {
         if (image.getFormat().hasAlpha()) {
             int width = image.getWidth();
             for (int y = 0; y < image.getHeight(); ++y) {
                 for (int x = 0; x < width; ++x) {
                     if (image.getOpacity(x, y) != -1) {
                         if (orMatch != null) {
-                            for (NativeImage[] nativeImages : orMatch) {
-                                for (NativeImage nativeImage : nativeImages) {
-                                    if (nativeImage.getOpacity(x, y) != -1) {
-                                        return true;
-                                    }
+                            for (NativeImage nativeImage : orMatch) {
+                                if (nativeImage.getOpacity(x, y) != -1) {
+                                    return true;
                                 }
                             }
                         } else {
@@ -60,14 +58,8 @@ public class SpriteUtils {
     }
 
     public static void printOpacity(@Nullable String id, Sprite sprite) {
-        int count = 0;
-        for (NativeImage img : ((SpriteOpacity)sprite).getImages()) {
-            if (!img.getFormat().hasOpacityChannel()) continue;
-            if (id == null) {
-                System.out.println(++count + ")");
-            } else {
-                System.out.println(id + " - " + (++count) + ")");
-            }
+        NativeImage img = ((SpriteOpacity) sprite).getUnmipmappedImage();
+        if (img.getFormat().hasOpacityChannel()) {
             printOpacity(img);
         }
     }


### PR DESCRIPTION
The downscaled images can't "create" opacity out of nothing, so we skip the check

Closes #60