### PR TITLE
Unbundle Cloth Config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
 
     //AutoConfig
     modCompileOnly "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}"
-    include "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}"
+    modApi "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}"
     // ^ Comment out to test without fabric api, this will require you to put the cloth-config in the mods folder
 }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,9 +30,7 @@
   "depends": {
     "fabricloader": ">=0.14.10",
     "minecraft": ">=1.19.4",
-    "java": ">=17"
-  },
-  "embedded": {
+    "java": ">=17",
     "cloth-config": ">=9.0.94"
   },
   "suggests": {


### PR DESCRIPTION
I recently realized that Cloth Config was the reason why MoreCulling is so large. 

Please unbundle it - it updates often, is already installed by many users (automatically a la CF Launcher or manually due to similar dependency), reduces mod size overall and redundancies on modpacks.