### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     api "me.shedaniel.cloth:cloth-config-neoforge:${project.cloth_config_version}"
 
     implementation "me.fallenbreath:conditional-mixin-neoforge:${project.conditional_mixins_version}"
-    implementation(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-common:${project.mixinsquared_version}"))
+    implementation(annotationProcessor("com.github.bawnorton:mixinsquared-common:${project.mixinsquared_version}"))
 }
 
 configurations {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     modImplementation("me.fallenbreath:conditional-mixin-fabric:${project.conditional_mixins_version}")
     include("me.fallenbreath:conditional-mixin-fabric:${project.conditional_mixins_version}")
 
-    include(implementation(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-fabric:${project.mixinsquared_version}")))
+    include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:${project.mixinsquared_version}")))
 }
 
 loom {

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -45,8 +45,8 @@ dependencies {
 
     implementation(jarJar("me.fallenbreath:conditional-mixin-neoforge:${project.conditional_mixins_version}"))
 
-    compileOnly(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-common:${project.mixinsquared_version}"))
-    implementation(jarJar("com.bawnorton.mixinsquared:mixinsquared-neoforge:${project.mixinsquared_version}"))
+    compileOnly(annotationProcessor("com.github.bawnorton:mixinsquared-common:${project.mixinsquared_version}"))
+    implementation(jarJar("com.github.bawnorton:mixinsquared-neoforge:${project.mixinsquared_version}"))
 }
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know at the time that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. 

This PR reverts that change to allow for compatibility with older versions of MixinSquared.

 I aplogize for the inconvenience, I was not aware of the implications of this change.

_This PR was generated automatically_