### PR TITLE
Disable culling against brewing stands

### DIFF
--- a/common/src/main/java/ca/fxco/moreculling/mixin/blocks/BrewingStandBlock_cullAgainstMixin.java
+++ b/common/src/main/java/ca/fxco/moreculling/mixin/blocks/BrewingStandBlock_cullAgainstMixin.java
@@ -1,0 +1,17 @@
+package ca.fxco.moreculling.mixin.blocks;
+
+import ca.fxco.moreculling.api.block.MoreBlockCulling;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.BrewingStandBlock;
+import net.minecraft.world.level.block.EndRodBlock;
+import net.minecraft.world.level.block.RodBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(BrewingStandBlock.class)
+public abstract class BrewingStandBlock_cullAgainstMixin implements MoreBlockCulling {
+    @Override
+    public boolean moreculling$cantCullAgainst(BlockState state, Direction side) {
+        return true;
+    }
+}

--- a/common/src/main/resources/moreculling.mixins.json
+++ b/common/src/main/resources/moreculling.mixins.json
@@ -19,6 +19,7 @@
     "blockentity.TheEndGatewayRenderer_beamMixin",
     "blockentity.SignRenderer_textMixin",
     "blocks.BaseRailBlock_cullAgainstMixin",
+    "blocks.BrewingStandBlock_cullAgainstMixin",
     "blocks.cullshape.CampfireBlock_voxelMixin",
     "blocks.cullshape.ChorusFlowerBlock_voxelMixin",
     "blocks.DoorBlock_cullAgainstMixin",


### PR DESCRIPTION
Fixes a bug where brewing stands would leave holes in the ground below them when connecting to a 1.12.2 server with ViaFabricPlus, and maybe other versions.