### PR TITLE
Fix utterly insignificant typo in cache clearing log message

### DIFF
--- a/common/src/main/java/ca/fxco/moreculling/utils/CacheUtils.java
+++ b/common/src/main/java/ca/fxco/moreculling/utils/CacheUtils.java
@@ -33,6 +33,6 @@ public class CacheUtils {
             }
         });
         //TODO: Reset quad cache
-        MoreCulling.LOGGER.info(allModels.size() + " cache(s) where cleared!");
+        MoreCulling.LOGGER.info(allModels.size() + " cache(s) were cleared!");
     }
 }


### PR DESCRIPTION
Just happened to notice it after closing the game one day.