### PR TITLE
Fix Rain Render Crash, Inverted Positions, Sodium Exclusions, and NeoForge World Querying

### DIFF
--- a/common/src/main/java/ca/fxco/moreculling/mixin/WeatherEffectRenderer_rainMixin.java
+++ b/common/src/main/java/ca/fxco/moreculling/mixin/WeatherEffectRenderer_rainMixin.java
@@ -33,15 +33,18 @@ public class WeatherEffectRenderer_rainMixin {
             return original.call(instance, pos);
         }
 
-        if (!((ExtendedLevelExtractor) Minecraft.getInstance().levelExtractor).moreculling$getFrustum().isVisible(new AABB(
-                pos.getX() + 1,
-                instance.getHeight(),
-                pos.getZ() + 1,
-                pos.getX(),
-                instance.getHeight(Heightmap.Types.MOTION_BLOCKING, pos.getX(), pos.getZ()),
-                pos.getZ()
-        ))) {
-            return Biome.Precipitation.NONE;
+        if (Minecraft.getInstance().levelExtractor instanceof ExtendedLevelExtractor extractor) {
+            Frustum frustum = extractor.moreculling$getFrustum();
+            if (frustum != null && !frustum.isVisible(new AABB(
+                    pos.getX() + 1,
+                    instance.getHeight(),
+                    pos.getZ() + 1,
+                    pos.getX(),
+                    instance.getHeight(Heightmap.Types.MOTION_BLOCKING, pos.getX(), pos.getZ()),
+                    pos.getZ()
+            ))) {
+                return Biome.Precipitation.NONE;
+            }
         }
 
         return original.call(instance, pos);

--- a/common/src/main/java/ca/fxco/moreculling/mixin/blocks/MangroveRootsBlock_typesMixin.java
+++ b/common/src/main/java/ca/fxco/moreculling/mixin/blocks/MangroveRootsBlock_typesMixin.java
@@ -52,7 +52,7 @@ public class MangroveRootsBlock_typesMixin extends Block implements MoreBlockCul
                                                               BlockState sideState, BlockPos thisPos,
                                                               BlockPos sidePos, Direction side) {
         return switch (MoreCulling.CONFIG.leavesCullingMode) { // Can't use state culling here
-            case CHECK -> CullingUtils.shouldDrawFaceCheck(view, sideState, sidePos, thisPos, side);
+            case CHECK -> CullingUtils.shouldDrawFaceCheck(view, sideState, thisPos, sidePos, side);
             case GAP -> CullingUtils.shouldDrawFaceGap(view, sideState, sidePos, side);
             case DEPTH -> CullingUtils.shouldDrawFaceDepth(view, sideState, sidePos, side);
             case RANDOM -> CullingUtils.shouldDrawFaceRandom(view, sideState, sidePos, side);

--- a/common/src/main/java/ca/fxco/moreculling/mixin/compat/BlockOcclusionCache_sodiumMixin.java
+++ b/common/src/main/java/ca/fxco/moreculling/mixin/compat/BlockOcclusionCache_sodiumMixin.java
@@ -1,6 +1,7 @@
 package ca.fxco.moreculling.mixin.compat;
 
 import ca.fxco.moreculling.MoreCulling;
+import ca.fxco.moreculling.api.blockstate.MoreStateCulling;
 import ca.fxco.moreculling.utils.CullingUtils;
 import com.llamalad7.mixinextras.sugar.Local;
 import me.fallenbreath.conditionalmixin.api.annotation.Condition;
@@ -48,7 +49,7 @@ public class BlockOcclusionCache_sodiumMixin {
             cancellable = true
     )
     private void moreculling$useMoreCulling(Direction facing, CallbackInfoReturnable<Boolean> cir, @Local BlockPos.MutableBlockPos adjPos) {
-        if (MoreCulling.CONFIG.useBlockStateCulling) {
+        if (MoreCulling.CONFIG.useBlockStateCulling && ((MoreStateCulling) (Object) state).moreculling$canCull()) {
             cir.setReturnValue(CullingUtils.shouldDrawSideCulling(state, level.getBlockState(adjPos), level, pos, facing, adjPos));
         }
     }

--- a/neoforge/src/main/java/ca/fxco/moreculling/mixin/blockstates/Block_neoforgeDrawSideMixin.java
+++ b/neoforge/src/main/java/ca/fxco/moreculling/mixin/blockstates/Block_neoforgeDrawSideMixin.java
@@ -33,7 +33,7 @@ public class Block_neoforgeDrawSideMixin implements MoreBlockCulling {
                                                          CallbackInfoReturnable<Boolean> cir) {
         if (MoreCulling.CONFIG.useBlockStateCulling && ((MoreStateCulling) thisState).moreculling$canCull()) {
             cir.setReturnValue(CullingUtils.shouldDrawSideCulling(thisState, sideState,
-                    EmptyBlockGetter.INSTANCE, pos, side, pos.relative(side)));
+                    level, pos, side, pos.relative(side)));
         }
     }
 }


### PR DESCRIPTION
Resolved a potential NullPointerException during rain frustum culling, fixed inverted block position arguments in mangrove roots culling, ensured `dontCull` configuration rules are respected under Sodium rendering, and passed the actual `BlockGetter` in NeoForge face culling mixins.