### PR TITLE
fix culling orientation, fabric feature renderer face filtering, sprite bounds check, and multithreading crashes

### DIFF
--- a/common/src/main/java/ca/fxco/moreculling/mixin/TextureAtlasSprite_opacityMixin.java
+++ b/common/src/main/java/ca/fxco/moreculling/mixin/TextureAtlasSprite_opacityMixin.java
@@ -33,7 +33,7 @@ public class TextureAtlasSprite_opacityMixin implements SpriteOpacity {
 
     @Override
     public boolean moreculling$hasTransparency(QuadBounds bounds) {
-        return SpriteUtils.doesHaveTransparency(moreculling$getUnmipmappedImage());
+        return SpriteUtils.doesHaveTransparency(moreculling$getUnmipmappedImage(), bounds);
     }
 
     @Override

--- a/common/src/main/java/ca/fxco/moreculling/utils/CacheUtils.java
+++ b/common/src/main/java/ca/fxco/moreculling/utils/CacheUtils.java
@@ -26,13 +26,15 @@ public class CacheUtils {
         }
         // Reset all model translucency cache
         Block.BLOCK_STATE_REGISTRY.forEach(state -> ((StateCullingShapeCache) state).moreculling$initCustomCullingShape());
-        Map<BlockState, BlockStateModel> allModels = ((BlockStateModelSetAccessor) bakedModelManager.getBlockStateModelSet()).getModels();
-        allModels.forEach((state, model) -> {
-            if (!state.canOcclude()) {
-                ((BakedOpacity) model).moreculling$resetTranslucencyCache(state);
-            }
-        });
-        //TODO: Reset quad cache
-        MoreCulling.LOGGER.info(allModels.size() + " cache(s) were cleared!");
+        if (bakedModelManager != null) {
+            Map<BlockState, BlockStateModel> allModels = ((BlockStateModelSetAccessor) bakedModelManager.getBlockStateModelSet()).getModels();
+            allModels.forEach((state, model) -> {
+                if (!state.canOcclude()) {
+                    ((BakedOpacity) model).moreculling$resetTranslucencyCache(state);
+                }
+            });
+            //TODO: Reset quad cache
+            MoreCulling.LOGGER.info(allModels.size() + " cache(s) were cleared!");
+        }
     }
 }

--- a/common/src/main/java/ca/fxco/moreculling/utils/CullingUtils.java
+++ b/common/src/main/java/ca/fxco/moreculling/utils/CullingUtils.java
@@ -222,6 +222,6 @@ public class CullingUtils {
         BlockPos posBehind = paintingPos.relative(oppositeDir, 1);
         BlockState blockState = Minecraft.getInstance().level.getBlockState(posBehind);
         return blockState.canOcclude() && ((StateCullingShapeCache) blockState)
-                .moreculling$getFaceCullingShape(oppositeDir) == Shapes.block();
+                .moreculling$getFaceCullingShape(oppositeDir.getOpposite()) == Shapes.block();
     }
 }

--- a/fabric/src/main/java/ca/fxco/moreculling/api/renderers/MorecullingFabricBlockModelFeatureRenderer.java
+++ b/fabric/src/main/java/ca/fxco/moreculling/api/renderers/MorecullingFabricBlockModelFeatureRenderer.java
@@ -53,7 +53,7 @@ public class MorecullingFabricBlockModelFeatureRenderer extends MorecullingBlock
             quadInstance.setOverlayCoords(submit.overlayCoords());
 
             for (BlockStateModelPart part : submit.modelParts()) {
-                putPartQuads(part, submit.pose(), quadInstance, submit.tintColor(), submit.tintLayers(), bufferCache);
+                putPartQuads(submit, part, submit.pose(), quadInstance, submit.tintColor(), submit.tintLayers(), bufferCache);
             }
 
             if (submit.mesh() != null) {
@@ -66,8 +66,11 @@ public class MorecullingFabricBlockModelFeatureRenderer extends MorecullingBlock
         submit = null;
     }
 
-    private void putPartQuads(BlockStateModelPart part, PoseStack.Pose pose, QuadInstance quadInstance, int baseTintColor, int[] tintLayers, BufferCache bufferCache) {
+    private void putPartQuads(MorecullingBlockModelSubmit submit, BlockStateModelPart part, PoseStack.Pose pose, QuadInstance quadInstance, int baseTintColor, int[] tintLayers, BufferCache bufferCache) {
         for (Direction direction : DirectionUtils.DIRECTIONS) {
+            if (submit.shouldCull(direction)) {
+                continue;
+            }
             for (BakedQuad quad : part.getQuads(direction)) {
                 VertexConsumer buffer = bufferCache.getBuffer(quad.materialInfo().layer());
 
@@ -80,6 +83,9 @@ public class MorecullingFabricBlockModelFeatureRenderer extends MorecullingBlock
         }
 
         for (BakedQuad quad : part.getQuads(null)) {
+            if (submit.shouldCull(quad.direction())) {
+                continue;
+            }
             VertexConsumer buffer = bufferCache.getBuffer(quad.materialInfo().layer());
 
             if (buffer == null) {

--- a/fabric/src/main/java/ca/fxco/moreculling/platform/FabricPlatformHelper.java
+++ b/fabric/src/main/java/ca/fxco/moreculling/platform/FabricPlatformHelper.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class FabricPlatformHelper implements IPlatformHelper {
-    private final List<BlockStateModelPart> parts = new ObjectArrayList<>();
 
     @Override
     public String getPlatformName() {
@@ -46,16 +45,11 @@ public class FabricPlatformHelper implements IPlatformHelper {
     public List<BakedQuad> getQuads(BlockStateModel model, BlockState state, Direction direction,
                                     RandomSource source, BlockAndTintGetter level, BlockPos pos) {
         List<BakedQuad> quads = new ArrayList<>();
+        List<BlockStateModelPart> parts = new ObjectArrayList<>();
         model.collectParts(source, parts);
 
-        if (!this.parts.isEmpty()) {
-            try {
-                for (BlockStateModelPart part : parts) {
-                    quads.addAll(part.getQuads(direction));
-                }
-            } finally {
-                this.parts.clear();
-            }
+        for (BlockStateModelPart part : parts) {
+            quads.addAll(part.getQuads(direction));
         }
 
         return quads;

--- a/neoforge/src/main/java/ca/fxco/moreculling/platform/NeoForgePlatformHelper.java
+++ b/neoforge/src/main/java/ca/fxco/moreculling/platform/NeoForgePlatformHelper.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class NeoForgePlatformHelper implements IPlatformHelper {
-    private final List<BlockStateModelPart> parts = new ObjectArrayList<>();
 
     @Override
     public String getPlatformName() {
@@ -48,16 +47,11 @@ public class NeoForgePlatformHelper implements IPlatformHelper {
     public List<BakedQuad> getQuads(BlockStateModel model, BlockState state, Direction direction,
                                     RandomSource source, BlockAndTintGetter level, BlockPos pos) {
         List<BakedQuad> quads = new ArrayList<>();
+        List<BlockStateModelPart> parts = new ObjectArrayList<>();
         model.collectParts(level, pos, state, source, parts);
 
-        if (!this.parts.isEmpty()) {
-            try {
-                for (BlockStateModelPart part : parts) {
-                    quads.addAll(part.getQuads(direction));
-                }
-            } finally {
-                this.parts.clear();
-            }
+        for (BlockStateModelPart part : parts) {
+            quads.addAll(part.getQuads(direction));
         }
 
         return quads;


### PR DESCRIPTION
- **Fixed adjacent wall face orientation in painting back-face culling (`CullingUtils#shouldCullPaintingBack`):**
  - *What:* Changed `moreculling$getFaceCullingShape(oppositeDir)` to query `oppositeDir.getOpposite()`.
  - *Why:* The wall block behind the painting is located at `posBehind = paintingPos.relative(oppositeDir)`. The face of that wall block that abuts the painting is its opposite face (`oppositeDir.getOpposite()`), pointing back towards the painting. Querying `oppositeDir` evaluated the far side of the wall block rather than the contact surface, leading to incorrect occlusion tests and visual artifacts when paintings were placed against directional or non-solid blocks.

- **Restored face culling filtering in the Fabric block model feature renderer (`MorecullingFabricBlockModelFeatureRenderer`):**
  - *What:* Passed `submit` to `putPartQuads` and guarded quad additions with `submit.shouldCull(direction)` and `submit.shouldCull(quad.direction())`.
  - *Why:* When running on Fabric with FRAPI active, `putPartQuads` previously iterated over all model part quads and submitted them unconditionally. This bypassed directional face culling rules defined by submit types like `BlockModelSubmitWithoutFace` or `BlockModelSubmitForFace`, rendering all faces and defeating optimizations.

- **Forwarded quad bounds in sprite transparency checks (`TextureAtlasSprite_opacityMixin`):**
  - *What:* Updated `moreculling$hasTransparency(QuadBounds bounds)` to pass `bounds` to `SpriteUtils.doesHaveTransparency(...)`.
  - *Why:* The overload previously ignored the provided `QuadBounds` argument and evaluated the entire sprite image. This caused quads whose specific UV region was completely opaque to be falsely identified as transparent if any other unrelated area of the texture atlas contained transparent pixels.

- **Added null check for `bakedModelManager` during cache resets (`CacheUtils#resetAllCache`):**
  - *What:* Wrapped the model translucency cache reset loop in an `if (bakedModelManager != null)` guard.
  - *Why:* `bakedModelManager` is populated during client setup. If a resource reload event fires before the model manager field is captured, calling `bakedModelManager.getBlockStateModelSet()` threw an unhandled `NullPointerException` that crashed the client during startup.

- **Eradicated shared mutable state in platform helper singletons (`FabricPlatformHelper` & `NeoForgePlatformHelper`):**
  - *What:* Removed the instance-level `parts` collection field and allocated the list locally inside `getQuads()`.
  - *Why:* Platform helpers are shared global singletons accessed via `Services.PLATFORM`. In multi-threaded rendering pipelines where chunk baking and model translucency caching occur across multiple worker threads simultaneously, sharing and clearing a single mutable list instance caused data races, missing quads, and `ConcurrentModificationException` crashes.